### PR TITLE
Add Makefile with a few useful build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# default make target.
+.PHONY: release
+release: fmt vet test build
+
+.PHONY: build
+build:
+	go build -v ./...
+
+.PHONY: fmt
+fmt:
+	go fmt ./...
+
+.PHONY: test
+test:
+	go test -v ./...
+
+.PHONY: vet
+vet:
+	go vet -v ./...


### PR DESCRIPTION
This code change adds a simple Makefile with a few useful build targets.

By default `make` with no specific target runs `release` which formats, vets, tests, and builds the code.