### PR TITLE
Allow log level to be customized with a flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var (
 	cognitoConfigFile    = flag.String("cognito-config", "env/CognitoConfig.json", "cognito config file; see env/SampleConfig.json for reference")
 	listsTableName       = flag.String("lists-table", "ListTable", "lists DynamoDB table name")
 	itemsTableName       = flag.String("items-table", "ItemsTable", "items DynamoDB table name")
+	logLevel             = flag.String("log-level", log.DebugLevel.String(), "log level")
 )
 
 func init() {
@@ -32,6 +33,12 @@ func init() {
 
 func main() {
 	log.SetReportCaller(true)
+	lgLvl, err := log.ParseLevel(*logLevel)
+	if err != nil {
+		log.Fatalf("failed to parse log level: %v", err)
+	}
+	log.SetLevel(lgLvl)
+	log.WithField("level", log.GetLevel().String()).Info("Log level set")
 
 	sess, err := session.NewSession(&aws.Config{
 		Region:      aws.String(*awsRegion),


### PR DESCRIPTION
# Overview

This code change adds a new flag, `log-level` that is used to set the log level of the server.

# Testing

`go run main.go --log-level=trace`

Logs indicated the default `debug` log level was set.

`go run main.go --log-level=trace`

Logs indicated the `trace` log level was set.