### PR TITLE
Refactor handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ curl -H "Authorization: Bearer TOKEN" http://localhost:8888/items
 Where the `TOKEN` is the same `TOKEN` you retrieved when getting the JWT token
 earlier.
 
+#### Examples
+
+**Creating a List**
+
+```
+curl -X PUT -d '{"ListID":"ID1","Title":"title"}' -H "Authorization: Bearer TOKEN" http://localhost:8888/lists
+```
+
 ### Advanced Configuration
 
 The yata server uses a series of optional command line flags to configure
@@ -145,3 +153,11 @@ values.
    `Failed to foo`.
 1. Use PascalCase or camelCase over other casings such as snake_case or
    kebab-case.
+
+## TODO
+
+Things we need to do. In no real order. Not comprehensive.
+
+1. Unit tests.
+1. Using a request-specific logger.
+1. Setting it up to be a Lambda function?

--- a/README.md
+++ b/README.md
@@ -101,10 +101,34 @@ earlier.
 
 #### Examples
 
-**Creating a List**
+**Listing all your items**
 
 ```
-curl -X PUT -d '{"ListID":"ID1","Title":"title"}' -H "Authorization: Bearer TOKEN" http://localhost:8888/lists
+curl -H "Authorization: Bearer TOKEN" http://localhost:8888/items
+```
+
+**Listing all your lists**
+
+```
+curl -H "Authorization: Bearer TOKEN" http://localhost:8888/lists
+```
+
+**Creating a list**
+
+```
+curl -X PUT -d '{"ListID":"ID1","Title":"My First List"}' -H "Authorization: Bearer TOKEN" http://localhost:8888/lists
+```
+
+**Adding an item to a list**
+
+```
+curl -X PUT -d '{"ItemID":"ID1","Content":"My First Item"}' -H "Authorization: Bearer TOKEN" http://localhost:8888/lists/<listID>/items
+```
+
+**Listing the items on a list**
+
+```
+curl -H "Authorization: Bearer TOKEN" http://localhost:8888/lists/<listID>/items
 ```
 
 ### Advanced Configuration
@@ -158,6 +182,6 @@ values.
 
 Things we need to do. In no real order. Not comprehensive.
 
-1. Unit tests.
+1. More unit tests.
 1. Using a request-specific logger.
-1. Setting it up to be a Lambda function?
+1. How do we deploy this thing?

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/sirupsen/logrus v1.7.0
+	github.com/stretchr/testify v1.2.2
 )

--- a/middleware/auth/cognitoJwtAuth.go
+++ b/middleware/auth/cognitoJwtAuth.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -54,7 +53,7 @@ func (middleware CognitoJwtAuthMiddleware) Execute(next http.Handler) http.Handl
 			return
 		}
 
-		r = r.WithContext(context.WithValue(r.Context(), request.UserIDContextKey, cognitoClaims.Subject))
+		r = r.WithContext(request.WithUserID(r.Context(), cognitoClaims.Subject))
 
 		if token.Valid {
 			next.ServeHTTP(w, r)

--- a/middleware/auth/cognitoJwtAuth.go
+++ b/middleware/auth/cognitoJwtAuth.go
@@ -53,6 +53,8 @@ func (middleware CognitoJwtAuthMiddleware) Execute(next http.Handler) http.Handl
 			return
 		}
 
+		log.WithField("claims", cognitoClaims).Debug("claims validated")
+
 		r = r.WithContext(request.WithUserID(r.Context(), cognitoClaims.Subject))
 
 		if token.Valid {

--- a/server/getitems.go
+++ b/server/getitems.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/TheYeung1/yata-server/model"
+	"github.com/TheYeung1/yata-server/server/request"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+)
+
+type GetAllItemsOutput struct {
+	Items []model.YataItem
+}
+
+func (s *Server) GetAllItems(w http.ResponseWriter, r *http.Request) {
+	uid, ok := request.UserID(r.Context())
+	if !ok {
+		log.Error("failed to get user ID from request context")
+		renderInternalServerError(w)
+		return
+	}
+	log.WithField("userID", uid).Debug("get all items called")
+
+	items, err := s.Ydb.GetAllItems(uid)
+	if err != nil {
+		log.WithError(err).Error("failed to get all items")
+		renderInternalServerError(w)
+		return
+	}
+
+	out := GetAllItemsOutput{Items: items}
+	log.WithField("output", out).Debug("items retrieved")
+	renderJSON(w, http.StatusOK, out)
+}
+
+type GetListItemsOutput struct {
+	Items []model.YataItem
+}
+
+func (s *Server) GetListItems(w http.ResponseWriter, r *http.Request) {
+	uid, ok := request.UserID(r.Context())
+	if !ok {
+		log.Error("failed to get user ID from request context")
+		renderInternalServerError(w)
+		return
+	}
+	log.WithField("userID", uid).Debug("get list items called")
+
+	v := mux.Vars(r)
+	listID := model.ListID(v["listID"])
+	if err := validateListID(listID); err != nil {
+		log.WithError(err).Info("failed to validate input")
+		renderBadRequest(w, err.Error())
+		return
+	}
+
+	items, err := s.Ydb.GetListItems(uid, listID)
+	if err != nil {
+		log.WithError(err).Error("failed to get list items")
+		renderInternalServerError(w)
+	}
+
+	out := GetListItemsOutput{Items: items}
+	log.WithField("output", out).Debug("list items retrieved")
+	renderJSON(w, http.StatusOK, out)
+}

--- a/server/getlists.go
+++ b/server/getlists.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/TheYeung1/yata-server/database"
+	"github.com/TheYeung1/yata-server/model"
+	"github.com/TheYeung1/yata-server/server/request"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+)
+
+type GetListOutput struct {
+	List model.YataList
+}
+
+func (s *Server) GetList(w http.ResponseWriter, r *http.Request) {
+	uid, ok := request.UserID(r.Context())
+	if !ok {
+		log.Error("failed to get user ID from request context")
+		renderInternalServerError(w)
+		return
+	}
+	log.WithField("userID", uid).Debug("get list called")
+
+	v := mux.Vars(r)
+	listID := model.ListID(v["listID"])
+	if err := validateListID(listID); err != nil {
+		log.WithError(err).Info("failed to validate input")
+		renderBadRequest(w, err.Error())
+		return
+	}
+
+	yl, err := s.Ydb.GetList(uid, listID)
+	if err != nil {
+		if errnf, ok := err.(database.ListNotFoundError); ok {
+			log.WithError(errnf).Info("list not found")
+			renderJSON(w, http.StatusNotFound, responseError{Code: "ListDoesNotExist", Message: "List does not exist"})
+			return
+		}
+		log.WithError(err).Error("failed to get list")
+		renderInternalServerError(w)
+		return
+	}
+
+	out := GetListOutput{List: yl}
+	log.WithField("output", out).Debug("list retrieved")
+	renderJSON(w, http.StatusOK, out)
+}
+
+type GetListsOutput struct {
+	Lists []model.YataList
+}
+
+func (s *Server) GetLists(w http.ResponseWriter, r *http.Request) {
+	uid, ok := request.UserID(r.Context())
+	if !ok {
+		log.Error("failed to get user ID from request context")
+		renderInternalServerError(w)
+		return
+	}
+	log.WithField("userID", uid).Debug("get lists called")
+
+	yl, err := s.Ydb.GetLists(uid)
+	if err != nil {
+		log.WithError(err).Error("failed to get lists")
+		renderInternalServerError(w)
+	}
+
+	out := GetListsOutput{Lists: yl}
+	log.WithField("output", out).Debug("lists retrieved")
+	renderJSON(w, http.StatusOK, out)
+}

--- a/server/insertitems.go
+++ b/server/insertitems.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/TheYeung1/yata-server/model"
+	"github.com/TheYeung1/yata-server/server/request"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+)
+
+type InsertListItemInput struct {
+	ItemID  string
+	Content string
+}
+
+// Validate returns an error if the input does not pass validation.
+func (input *InsertListItemInput) Validate() error {
+	if len(input.ItemID) == 0 {
+		return errors.New("ItemID cannot be empty")
+	}
+	if len(input.ItemID) > 100 {
+		return errors.New("ItemID length cannot exceed 100 characters")
+	}
+	if len(input.ItemID) != len(strings.TrimSpace(input.ItemID)) {
+		return errors.New("ItemID cannot be prefixed or suffixed with spaces")
+	}
+	if len(input.Content) == 0 {
+		return errors.New("Content cannot be empty")
+	}
+	if len(input.Content) > 100 {
+		return errors.New("Content length cannot exceed 100 characters")
+	}
+	if len(input.Content) != len(strings.TrimSpace(input.Content)) {
+		return errors.New("Content cannot be prefixed or suffixed with spaces")
+	}
+	return nil
+}
+
+type InsertListItemOutput struct {
+	ItemID string
+}
+
+func (s *Server) InsertListItem(w http.ResponseWriter, r *http.Request) {
+	uid, ok := request.UserID(r.Context())
+	if !ok {
+		log.Error("failed to get user ID from request context")
+		renderInternalServerError(w)
+		return
+	}
+
+	var input InsertListItemInput
+	if err := bindJSON(r.Body, &input); err != nil {
+		log.WithError(err).Info("failed to bind input")
+		renderBadRequest(w, "malformed input")
+		return
+	}
+	log.WithField("input", input).Debug("input bound")
+
+	v := mux.Vars(r)
+	listID := model.ListID(v["listID"])
+	if err := validateListID(listID); err != nil {
+		log.WithError(err).Info("failed to validate input")
+		renderBadRequest(w, err.Error())
+		return
+	}
+	if err := input.Validate(); err != nil {
+		log.WithError(err).Info("failed to normalize and validate input")
+		renderBadRequest(w, err.Error())
+		return
+	}
+
+	yi := model.YataItem{
+		UserID:  uid,
+		ListID:  model.ListID(v["listID"]),
+		ItemID:  model.ItemID(input.ItemID),
+		Content: input.Content,
+	}
+	log.WithField("item", yi).Debug("inserting item")
+	if err := s.Ydb.InsertItem(yi); err != nil {
+		log.WithError(err).Error("failed to insert item")
+		renderInternalServerError(w)
+		return
+	}
+
+	out := InsertListItemOutput{ItemID: input.ItemID}
+	log.WithField("output", out).Debug("item inserted")
+	renderJSON(w, http.StatusCreated, out)
+}

--- a/server/insertlist.go
+++ b/server/insertlist.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/TheYeung1/yata-server/database"
 	"github.com/TheYeung1/yata-server/model"
+	"github.com/TheYeung1/yata-server/server/request"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -43,9 +44,9 @@ type InsertListOutput struct {
 }
 
 func (s *Server) InsertList(w http.ResponseWriter, r *http.Request) {
-	uid, err := getUserIDFromContext(r)
-	if err != nil {
-		log.WithError(err).Error("failed to get user ID from request context")
+	uid, ok := request.UserID(r.Context())
+	if !ok {
+		log.Error("failed to get user ID from request context")
 		renderInternalServerError(w)
 		return
 	}
@@ -66,7 +67,7 @@ func (s *Server) InsertList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	yl := model.YataList{
-		UserID: model.UserID(uid[0]),
+		UserID: uid,
 		ListID: model.ListID(input.ListID),
 		Title:  input.Title,
 	}
@@ -85,51 +86,4 @@ func (s *Server) InsertList(w http.ResponseWriter, r *http.Request) {
 	out := InsertListOutput{ListID: input.ListID}
 	log.WithField("output", out).Debug("list inserted")
 	renderJSON(w, http.StatusCreated, out)
-}
-
-func NewInsertListHandler(insertList func(model.UserID, model.YataList) error) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		uid, err := getUserIDFromContext(r)
-		if err != nil {
-			log.WithError(err).Error("failed to get user ID from request context")
-			renderInternalServerError(w)
-			return
-		}
-		log.WithField("userID", uid).Debug("insert list called")
-
-		var input InsertListInput
-		if err := bindJSON(r.Body, &input); err != nil {
-			log.WithError(err).Info("failed to bind input")
-			renderBadRequest(w, "malformed input")
-			return
-		}
-		log.WithField("input", input).Debug("input bound")
-
-		if err := input.Validate(); err != nil {
-			log.WithError(err).Info("failed to normalize and validate input")
-			renderBadRequest(w, err.Error())
-			return
-		}
-
-		yl := model.YataList{
-			UserID: model.UserID(uid[0]),
-			ListID: model.ListID(input.ListID),
-			Title:  input.Title,
-		}
-		log.WithField("list", yl).Debug("inserting list")
-		if err := insertList(yl.UserID, yl); err != nil {
-			if errnf, ok := err.(database.ListExistsError); ok {
-				log.WithError(errnf).Info("list not found")
-				renderJSON(w, http.StatusConflict, responseError{Code: "ListExists", Message: "List already exists"})
-				return
-			}
-			log.WithError(err).Error("failed to insert list")
-			renderInternalServerError(w)
-			return
-		}
-
-		out := InsertListOutput{ListID: input.ListID}
-		log.WithField("output", out).Debug("list inserted")
-		renderJSON(w, http.StatusCreated, out)
-	}
 }

--- a/server/insertlist_test.go
+++ b/server/insertlist_test.go
@@ -15,50 +15,50 @@ import (
 )
 
 func TestInsertListInput_Validate(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		input InsertListInput
 		err   error
 	}{
-		{
+		"validate-input": {
 			input: InsertListInput{ListID: "ID", Title: "Title"},
 		},
-		{
+		"list-id-empty": {
 			input: InsertListInput{ListID: ""},
 			err:   errors.New("ListID cannot be empty"),
 		},
-		{
+		"list-id-too-long": {
 			input: InsertListInput{ListID: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque porta eros erat. Curabitur nam."},
 			err:   errors.New("ListID length cannot exceed 100 characters"),
 		},
-		{
+		"list-id-with-trailing-space": {
 			input: InsertListInput{ListID: "ID "},
 			err:   errors.New("ListID cannot be prefixed or suffixed with spaces"),
 		},
-		{
+		"list-id-with-leading-space": {
 			input: InsertListInput{ListID: " ID"},
 			err:   errors.New("ListID cannot be prefixed or suffixed with spaces"),
 		},
-		{
+		"title-empty": {
 			input: InsertListInput{ListID: "ID"},
 			err:   errors.New("Title cannot be empty"),
 		},
-		{
+		"title-too-long": {
 			input: InsertListInput{ListID: "ID", Title: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque porta eros erat. Curabitur nam."},
 			err:   errors.New("Title length cannot exceed 100 characters"),
 		},
-		{
+		"title-id-with-trailing-space": {
 			input: InsertListInput{ListID: "ID", Title: "Title "},
 			err:   errors.New("Title cannot be prefixed or suffixed with spaces"),
 		},
-		{
+		"title-id-with-leading-space": {
 			input: InsertListInput{ListID: "ID", Title: " Title"},
 			err:   errors.New("Title cannot be prefixed or suffixed with spaces"),
 		},
 	}
 
-	for _, test := range tests {
-		test := test
-		t.Run(fmt.Sprintf("%+v", test.input), func(t *testing.T) {
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(fmt.Sprintf(name), func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, test.err, test.input.Validate())
 		})
@@ -66,19 +66,19 @@ func TestInsertListInput_Validate(t *testing.T) {
 }
 
 func TestServer_InsertList(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		input      string
 		insertList func(*testing.T) func(id model.UserID, list model.YataList) error
 		outCode    int
 		outBody    string
 	}{
-		{
+		"happy-path": {
 			input: "{\"ListID\":\"ID\",\"Title\":\"Title\"}",
 			insertList: func(t *testing.T) func(id model.UserID, list model.YataList) error {
 				return func(id model.UserID, list model.YataList) error {
-					assert.Equal(t, model.UserID("u"), id)
+					assert.Equal(t, "userID", string(id))
 					assert.Equal(t, model.YataList{
-						UserID: "u",
+						UserID: "userID",
 						ListID: "ID",
 						Title:  "Title",
 					}, list)
@@ -88,17 +88,37 @@ func TestServer_InsertList(t *testing.T) {
 			outCode: http.StatusCreated,
 			outBody: "{\"ListID\":\"ID\"}\n",
 		},
+		"insertion-error": {
+			input: "{\"ListID\":\"ID\",\"Title\":\"Title\"}",
+			insertList: func(t *testing.T) func(id model.UserID, list model.YataList) error {
+				return func(id model.UserID, list model.YataList) error {
+					return errors.New("boom")
+				}
+			},
+			outCode: http.StatusInternalServerError,
+			outBody: "{\"Code\":\"InternalServerError\"}\n",
+		},
+		"list-already-exists": {
+			input: "{\"ListID\":\"ID\",\"Title\":\"Title\"}",
+			insertList: func(t *testing.T) func(id model.UserID, list model.YataList) error {
+				return func(id model.UserID, list model.YataList) error {
+					return database.ListExistsError{}
+				}
+			},
+			outCode: http.StatusConflict,
+			outBody: "{\"Code\":\"ListExists\",\"Message\":\"List already exists\"}\n",
+		},
 	}
 
-	for _, test := range tests {
-		test := test
-		t.Run(fmt.Sprintf("%+v", test.input), func(t *testing.T) {
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(fmt.Sprintf(name), func(t *testing.T) {
 			t.Parallel()
 
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest( /* Method */ "", "https://does.not/matter", bytes.NewBufferString(test.input))
 
-			srvr := Server{Ydb: MockTdb{MockInsertList: test.insertList(t)}}
+			srvr := Server{Ydb: mockYdb{MockInsertList: test.insertList(t)}}
 
 			srvr.InsertList(rec, req.WithContext(request.WithUserID(req.Context(), "userID")))
 
@@ -108,74 +128,32 @@ func TestServer_InsertList(t *testing.T) {
 	}
 }
 
-var _ database.YataDatabase = MockTdb{}
+var _ database.YataDatabase = mockYdb{}
 
-type MockTdb struct {
+type mockYdb struct {
 	MockInsertList func(id model.UserID, list model.YataList) error
 }
 
-func (m MockTdb) GetList(id model.UserID, id2 model.ListID) (model.YataList, error) {
+func (m mockYdb) GetList(id model.UserID, id2 model.ListID) (model.YataList, error) {
 	panic("implement me")
 }
 
-func (m MockTdb) GetLists(id model.UserID) ([]model.YataList, error) {
+func (m mockYdb) GetLists(id model.UserID) ([]model.YataList, error) {
 	panic("implement me")
 }
 
-func (m MockTdb) InsertList(id model.UserID, list model.YataList) error {
+func (m mockYdb) InsertList(id model.UserID, list model.YataList) error {
 	return m.MockInsertList(id, list)
 }
 
-func (m MockTdb) GetAllItems(id model.UserID) ([]model.YataItem, error) {
+func (m mockYdb) GetAllItems(id model.UserID) ([]model.YataItem, error) {
 	panic("implement me")
 }
 
-func (m MockTdb) GetListItems(id model.UserID, id2 model.ListID) ([]model.YataItem, error) {
+func (m mockYdb) GetListItems(id model.UserID, id2 model.ListID) ([]model.YataItem, error) {
 	panic("implement me")
 }
 
-func (m MockTdb) InsertItem(item model.YataItem) error {
+func (m mockYdb) InsertItem(item model.YataItem) error {
 	panic("implement me")
-}
-
-func TestNewInsertListHandler(t *testing.T) {
-	tests := []struct {
-		input      string
-		insertList func(*testing.T) func(id model.UserID, list model.YataList) error
-		outCode    int
-		outBody    string
-	}{
-		{
-			input: "{\"ListID\":\"ID\",\"Title\":\"Title\"}",
-			insertList: func(t *testing.T) func(id model.UserID, list model.YataList) error {
-				return func(id model.UserID, list model.YataList) error {
-					assert.Equal(t, model.UserID("u"), id)
-					assert.Equal(t, model.YataList{
-						UserID: "u",
-						ListID: "ID",
-						Title:  "Title",
-					}, list)
-					return nil
-				}
-			},
-			outCode: http.StatusCreated,
-			outBody: "{\"ListID\":\"ID\"}\n",
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(fmt.Sprintf("%+v", test.input), func(t *testing.T) {
-			t.Parallel()
-
-			rec := httptest.NewRecorder()
-			req := httptest.NewRequest( /* Method */ "", "https://does.not/matter", bytes.NewBufferString(test.input))
-			handler := NewInsertListHandler(test.insertList(t))
-
-			handler(rec, req.WithContext(request.WithUserID(req.Context(), "userID")))
-
-			assert.Equal(t, test.outCode, rec.Code)
-			assert.Equal(t, test.outBody, rec.Body.String())
-		})
-	}
 }

--- a/server/insertlist_test.go
+++ b/server/insertlist_test.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/TheYeung1/yata-server/database"
+	"github.com/TheYeung1/yata-server/model"
+	"github.com/TheYeung1/yata-server/server/request"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInsertListInput_Validate(t *testing.T) {
+	tests := []struct {
+		input InsertListInput
+		err   error
+	}{
+		{
+			input: InsertListInput{ListID: "ID", Title: "Title"},
+		},
+		{
+			input: InsertListInput{ListID: ""},
+			err:   errors.New("ListID cannot be empty"),
+		},
+		{
+			input: InsertListInput{ListID: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque porta eros erat. Curabitur nam."},
+			err:   errors.New("ListID length cannot exceed 100 characters"),
+		},
+		{
+			input: InsertListInput{ListID: "ID "},
+			err:   errors.New("ListID cannot be prefixed or suffixed with spaces"),
+		},
+		{
+			input: InsertListInput{ListID: " ID"},
+			err:   errors.New("ListID cannot be prefixed or suffixed with spaces"),
+		},
+		{
+			input: InsertListInput{ListID: "ID"},
+			err:   errors.New("Title cannot be empty"),
+		},
+		{
+			input: InsertListInput{ListID: "ID", Title: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque porta eros erat. Curabitur nam."},
+			err:   errors.New("Title length cannot exceed 100 characters"),
+		},
+		{
+			input: InsertListInput{ListID: "ID", Title: "Title "},
+			err:   errors.New("Title cannot be prefixed or suffixed with spaces"),
+		},
+		{
+			input: InsertListInput{ListID: "ID", Title: " Title"},
+			err:   errors.New("Title cannot be prefixed or suffixed with spaces"),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("%+v", test.input), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.err, test.input.Validate())
+		})
+	}
+}
+
+func TestServer_InsertList(t *testing.T) {
+	tests := []struct {
+		input      string
+		insertList func(*testing.T) func(id model.UserID, list model.YataList) error
+		outCode    int
+		outBody    string
+	}{
+		{
+			input: "{\"ListID\":\"ID\",\"Title\":\"Title\"}",
+			insertList: func(t *testing.T) func(id model.UserID, list model.YataList) error {
+				return func(id model.UserID, list model.YataList) error {
+					assert.Equal(t, model.UserID("u"), id)
+					assert.Equal(t, model.YataList{
+						UserID: "u",
+						ListID: "ID",
+						Title:  "Title",
+					}, list)
+					return nil
+				}
+			},
+			outCode: http.StatusCreated,
+			outBody: "{\"ListID\":\"ID\"}\n",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("%+v", test.input), func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest( /* Method */ "", "https://does.not/matter", bytes.NewBufferString(test.input))
+
+			srvr := Server{Ydb: MockTdb{MockInsertList: test.insertList(t)}}
+
+			srvr.InsertList(rec, req.WithContext(request.WithUserID(req.Context(), "userID")))
+
+			assert.Equal(t, test.outCode, rec.Code)
+			assert.Equal(t, test.outBody, rec.Body.String())
+		})
+	}
+}
+
+var _ database.YataDatabase = MockTdb{}
+
+type MockTdb struct {
+	MockInsertList func(id model.UserID, list model.YataList) error
+}
+
+func (m MockTdb) GetList(id model.UserID, id2 model.ListID) (model.YataList, error) {
+	panic("implement me")
+}
+
+func (m MockTdb) GetLists(id model.UserID) ([]model.YataList, error) {
+	panic("implement me")
+}
+
+func (m MockTdb) InsertList(id model.UserID, list model.YataList) error {
+	return m.MockInsertList(id, list)
+}
+
+func (m MockTdb) GetAllItems(id model.UserID) ([]model.YataItem, error) {
+	panic("implement me")
+}
+
+func (m MockTdb) GetListItems(id model.UserID, id2 model.ListID) ([]model.YataItem, error) {
+	panic("implement me")
+}
+
+func (m MockTdb) InsertItem(item model.YataItem) error {
+	panic("implement me")
+}
+
+func TestNewInsertListHandler(t *testing.T) {
+	tests := []struct {
+		input      string
+		insertList func(*testing.T) func(id model.UserID, list model.YataList) error
+		outCode    int
+		outBody    string
+	}{
+		{
+			input: "{\"ListID\":\"ID\",\"Title\":\"Title\"}",
+			insertList: func(t *testing.T) func(id model.UserID, list model.YataList) error {
+				return func(id model.UserID, list model.YataList) error {
+					assert.Equal(t, model.UserID("u"), id)
+					assert.Equal(t, model.YataList{
+						UserID: "u",
+						ListID: "ID",
+						Title:  "Title",
+					}, list)
+					return nil
+				}
+			},
+			outCode: http.StatusCreated,
+			outBody: "{\"ListID\":\"ID\"}\n",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("%+v", test.input), func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest( /* Method */ "", "https://does.not/matter", bytes.NewBufferString(test.input))
+			handler := NewInsertListHandler(test.insertList(t))
+
+			handler(rec, req.WithContext(request.WithUserID(req.Context(), "userID")))
+
+			assert.Equal(t, test.outCode, rec.Code)
+			assert.Equal(t, test.outBody, rec.Body.String())
+		})
+	}
+}

--- a/server/request/context.go
+++ b/server/request/context.go
@@ -5,19 +5,19 @@ import (
 	"github.com/TheYeung1/yata-server/model"
 )
 
-type CtxKey string
+type ctxKey string
 
-const UserIDContextKey CtxKey = "UserID"
+const userIDContextKey ctxKey = "UserID"
 
 // WithUserID stores the userID on the returned context.
 func WithUserID(ctx context.Context, userID string) context.Context {
-	return context.WithValue(ctx, UserIDContextKey, userID)
+	return context.WithValue(ctx, userIDContextKey, userID)
 }
 
 // UserID returns the userID stored on the context.
 // If the userID was found it will return true, false otherwise.
 func UserID(ctx context.Context) (model.UserID, bool) {
-	val := ctx.Value(UserIDContextKey)
+	val := ctx.Value(userIDContextKey)
 	str, ok := val.(string)
 	return model.UserID(str), ok
 }

--- a/server/request/context.go
+++ b/server/request/context.go
@@ -1,5 +1,23 @@
 package request
 
-type RequestContextKey string
+import (
+	"context"
+	"github.com/TheYeung1/yata-server/model"
+)
 
-const UserIDContextKey RequestContextKey = "UserID"
+type CtxKey string
+
+const UserIDContextKey CtxKey = "UserID"
+
+// WithUserID stores the userID on the returned context.
+func WithUserID(ctx context.Context, userID string) context.Context {
+	return context.WithValue(ctx, UserIDContextKey, userID)
+}
+
+// UserID returns the userID stored on the context.
+// If the userID was found it will return true, false otherwise.
+func UserID(ctx context.Context) (model.UserID, bool) {
+	val := ctx.Value(UserIDContextKey)
+	str, ok := val.(string)
+	return model.UserID(str), ok
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,14 +1,11 @@
 package server
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/TheYeung1/yata-server/config"
 	"github.com/TheYeung1/yata-server/database"
 	"github.com/TheYeung1/yata-server/middleware/auth"
-	"github.com/TheYeung1/yata-server/model"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 )
@@ -16,179 +13,6 @@ import (
 type Server struct {
 	CognitoCfg config.AwsCognitoUserPoolConfig
 	Ydb        database.YataDatabase
-}
-
-type InsertListItemInput struct {
-	ItemID  string
-	Content string
-}
-
-func writeInternalErrorResponse(w http.ResponseWriter) {
-	w.WriteHeader(http.StatusInternalServerError)
-	_, _ = w.Write([]byte("Sorry! Something went wrong"))
-}
-
-func (s *Server) GetList(w http.ResponseWriter, r *http.Request) {
-	v := mux.Vars(r)
-
-	userID, err := getUserIDFromContext(r)
-	if err != nil {
-		log.WithError(err).Error("failed to get user ID from request context")
-		writeInternalErrorResponse(w)
-		return
-	}
-	listID := model.ListID(v["listID"])
-
-	yl, err := s.Ydb.GetList(userID, listID)
-	if err != nil {
-		if lnf, ok := err.(database.ListNotFoundError); ok {
-			log.WithError(lnf).Info("list not found")
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte("List not found"))
-			return
-		}
-		log.WithError(err).Error("failed to get list")
-		writeInternalErrorResponse(w)
-		return
-	}
-
-	res, err := json.Marshal(yl)
-	if err != nil {
-		log.WithError(err).Error("failed to marshal json")
-		writeInternalErrorResponse(w)
-	}
-	_, err = w.Write(res)
-	if err != nil {
-		log.WithError(err).Error("failed to write response")
-	}
-}
-
-func (s *Server) GetLists(w http.ResponseWriter, r *http.Request) {
-	userID, err := getUserIDFromContext(r)
-	if err != nil {
-		log.WithError(err).Error("failed to get user ID from request context")
-		writeInternalErrorResponse(w)
-		return
-	}
-
-	yl, err := s.Ydb.GetLists(userID)
-	if err != nil {
-		log.WithError(err).Error("failed to get lists")
-		writeInternalErrorResponse(w)
-	}
-
-	res, err := json.Marshal(yl)
-	if err != nil {
-		log.WithError(err).Error("failed to marshal json")
-		writeInternalErrorResponse(w)
-	}
-
-	_, err = w.Write(res)
-	if err != nil {
-		log.WithError(err).Error("failed to write response")
-	}
-}
-
-func (s *Server) InsertListItem(w http.ResponseWriter, r *http.Request) {
-	//TODO: add validation to inputs
-	b, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.WithError(err).Error("failed to read request")
-		writeInternalErrorResponse(w)
-		return
-	}
-
-	var in InsertListItemInput
-	err = json.Unmarshal(b, &in)
-	if err != nil {
-		log.WithError(err).Error("failed to unmarshal request")
-		writeInternalErrorResponse(w)
-		return
-	}
-
-	uid, err := getUserIDFromContext(r)
-	if err != nil {
-		log.WithError(err).Error("failed to get user ID from request context")
-		writeInternalErrorResponse(w)
-		return
-	}
-	v := mux.Vars(r)
-
-	// TODO: assert input lengths
-	item := model.YataItem{
-		UserID:  model.UserID(uid[0]),
-		ListID:  model.ListID(v["listID"]),
-		ItemID:  model.ItemID(in.ItemID),
-		Content: in.Content,
-	}
-
-	// insert list to db here
-	err = s.Ydb.InsertItem(item)
-	if err != nil {
-		log.WithError(err).Error("failed to insert item")
-		writeInternalErrorResponse(w)
-	}
-
-	w.WriteHeader(http.StatusCreated)
-	_, err = w.Write([]byte{})
-	if err != nil {
-		log.WithError(err).Error("failed to write response")
-	}
-}
-
-func (s *Server) GetListItems(w http.ResponseWriter, r *http.Request) {
-	v := mux.Vars(r)
-
-	userID, err := getUserIDFromContext(r)
-	if err != nil {
-		log.WithError(err).Error("failed to get user ID from request context")
-		writeInternalErrorResponse(w)
-		return
-	}
-	listID := model.ListID(v["listID"])
-
-	items, err := s.Ydb.GetListItems(userID, listID)
-	if err != nil {
-		log.WithError(err).Error("failed to get list items")
-		writeInternalErrorResponse(w)
-	}
-
-	res, err := json.Marshal(items)
-	if err != nil {
-		log.WithError(err).Error("failed to marshal json")
-		writeInternalErrorResponse(w)
-	}
-
-	_, err = w.Write(res)
-	if err != nil {
-		log.WithError(err).Error("failed to write response")
-	}
-}
-
-func (s *Server) GetAllItems(w http.ResponseWriter, r *http.Request) {
-	userID, err := getUserIDFromContext(r)
-	if err != nil {
-		log.WithError(err).Error("failed to get user ID from request context")
-		writeInternalErrorResponse(w)
-		return
-	}
-
-	items, err := s.Ydb.GetAllItems(userID)
-	if err != nil {
-		log.WithError(err).Error("failed to get all items")
-		writeInternalErrorResponse(w)
-	}
-
-	res, err := json.Marshal(items)
-	if err != nil {
-		log.WithError(err).Error("failed to marshal json")
-		writeInternalErrorResponse(w)
-	}
-
-	_, err = w.Write(res)
-	if err != nil {
-		log.WithError(err).Error("failed to write response")
-	}
 }
 
 func (s *Server) Start() {
@@ -199,7 +23,6 @@ func (s *Server) Start() {
 	r.HandleFunc("/items", s.GetAllItems).Methods(http.MethodGet)
 	r.HandleFunc("/lists", s.GetLists).Methods(http.MethodGet)
 	r.HandleFunc("/lists", s.InsertList).Methods(http.MethodPut)
-	r.HandleFunc("/lists-alternate", NewInsertListHandler(s.Ydb.InsertList)).Methods(http.MethodPut)
 	r.HandleFunc("/lists/{listID}/", s.GetList).Methods(http.MethodGet)
 	r.HandleFunc("/lists/{listID}/items", s.GetListItems).Methods(http.MethodGet)
 	r.HandleFunc("/lists/{listID}/items", s.InsertListItem).Methods(http.MethodPut)

--- a/server/util.go
+++ b/server/util.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/TheYeung1/yata-server/model"
+	"github.com/TheYeung1/yata-server/server/request"
+	log "github.com/sirupsen/logrus"
+)
+
+// getUserIDFromContext returns the userID stored on the request context.
+// A non-nil error will be returned if the userID cannot be found.
+// Deprecated: use request.UserID instead.
+func getUserIDFromContext(r *http.Request) (model.UserID, error) {
+	val := r.Context().Value(request.UserIDContextKey)
+	str, ok := val.(string)
+	if ok {
+		return model.UserID(str), nil
+	}
+	return "", errors.New("userID context is not a string value")
+}
+
+// bindJSON decodes r into v.
+// v must be a pointer.
+// Q: Why such a small function?
+// A: We might want to put limits on how much we read in the future.
+// A: If we decide to ever support other input formats (XML?) this can become a generic "Bind" function.
+// In an ideal world we might want to look at the incoming request's "Content-Type" header.
+func bindJSON(r io.Reader, v interface{}) error {
+	return json.NewDecoder(r).Decode(v)
+}
+
+type responseError struct {
+	Code    string
+	Message string `json:"omitempty"`
+}
+
+// renderJSON writes the response code, sets the content type for JSON, and encodes v as JSON to w.
+// In an ideal world we might want to look at the incoming request's "Accept" header.
+func renderJSON(w http.ResponseWriter, code int, v interface{}) {
+	w.WriteHeader(code)
+	w.Header().Set("Content-Type", "application/json") // FYI: https://stackoverflow.com/questions/477816/what-is-the-correct-json-content-type
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.WithError(err).Warn("failed to render json")
+	}
+}
+
+func renderInternalServerError(w http.ResponseWriter) {
+	renderJSON(w, http.StatusInternalServerError, responseError{Code: "InternalServerError"})
+}
+
+func renderBadRequest(w http.ResponseWriter, msg string) {
+	renderJSON(w, http.StatusBadRequest, responseError{Code: "BadRequest", Message: msg})
+}


### PR DESCRIPTION
# Overview

This code change refactors all the handlers as we decided (see comments below).
1. Inputs are either restful (on the path) or clearly defined `struct`s.
2. Inputs are validated.
2. Outputs are clearly defined `struct`s.
3. Errors use both HTTP status codes and error codes specified in the JSON response body.
4. Tests were added for InsertList. More unit testing should be added later.
5. `WithUserID` and `UserID` helpers added.
6. Logging was added.
7. Additional examples added to the readme.
8. Handlers moved to separate files.

Open item but not blocking for this PR:

I think we should consider abandoning RESTful routes and adopt a simple RPC based framework:
1. Only POST requests.
2. Each API has a separate endpoint, `/list-items`, `/list-lists`, etc
3. Inputs to APIs are JSON-encoded payloads.
4. Outputs from APIs are JSON-encoded payloads.

I've gone back and forth with RESTful frameworks and RPC frameworks and I personally find RPC based frameworks easier to reason about and use. RESTful routes for the frontend are fine (the web is all GET all the time).