### PR TITLE
Add GET /me API that returns information about the current user

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ earlier.
 
 #### Examples
 
+**Figuring out who you are**
+
+```
+curl -H "Authorization: Bearer TOKEN" http://localhost:8888/me
+```
+
 **Listing all your items**
 
 ```

--- a/server/server.go
+++ b/server/server.go
@@ -26,5 +26,6 @@ func (s *Server) Start() {
 	r.HandleFunc("/lists/{listID}/", s.GetList).Methods(http.MethodGet)
 	r.HandleFunc("/lists/{listID}/items", s.GetListItems).Methods(http.MethodGet)
 	r.HandleFunc("/lists/{listID}/items", s.InsertListItem).Methods(http.MethodPut)
+	r.HandleFunc("/me", s.WhoAmI).Methods(http.MethodGet)
 	log.Fatal(http.ListenAndServe(addr, r))
 }

--- a/server/whoami.go
+++ b/server/whoami.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/TheYeung1/yata-server/middleware/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+type WhoAmIOutput struct {
+	EmailVerified bool
+	TokenUse      string
+	AuthTime      int64
+	UserName      string
+	GivenName     string
+	Email         string
+
+	// Standard JWT claims.
+	Audience  string
+	ExpiresAt int64
+	Id        string
+	IssuedAt  int64
+	Issuer    string
+	NotBefore int64
+	Subject   string
+}
+
+func (s *Server) WhoAmI(w http.ResponseWriter, r *http.Request) {
+	claims, ok := auth.CognitoClaims(r.Context())
+	if !ok || claims == nil {
+		log.Error("failed to get user ID from request context")
+		renderInternalServerError(w)
+		return
+	}
+
+	out := WhoAmIOutput{
+		EmailVerified: claims.EmailVerified,
+		TokenUse:      claims.TokenUse,
+		AuthTime:      claims.AuthTime,
+		UserName:      claims.UserName,
+		GivenName:     claims.GivenName,
+		Email:         claims.Email,
+
+		Audience:  claims.Audience,
+		ExpiresAt: claims.ExpiresAt,
+		Id:        claims.Id,
+		IssuedAt:  claims.IssuedAt,
+		Issuer:    claims.Issuer,
+		NotBefore: claims.NotBefore,
+		Subject:   claims.Subject,
+	}
+	log.WithField("output", out).Debug("user determined")
+	renderJSON(w, http.StatusOK, out)
+}


### PR DESCRIPTION
# Overview

This code change adds a new route, `GET /me`, that returns information about the currently logged in user.

# Testing

1. ran the server.
2. hit the new endpoint:
```
curl -H "Authorization: Bearer TOKEN" http://localhost:8888/me

{
	"EmailVerified": true,
	"TokenUse": "id",
	"AuthTime": 1609777242,
	"UserName": "harrison",
	"GivenName": "",
	"Email": "harrisonhjones@gmail.com",
	"Audience": "REDACTED",
	"ExpiresAt": 1609780842,
	"Id": "",
	"IssuedAt": 1609777242,
	"Issuer": "https://cognito-idp.us-east-1.amazonaws.com/REDACTED",
	"NotBefore": 0,
	"Subject": "REDACTED"
}
```