### PR TITLE
Use a separate logger per request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.36.18
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/google/uuid v1.1.4
 	github.com/gorilla/mux v1.8.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/google/uuid v1.1.4 h1:0ecGp3skIrHWPNGPJDaBIghfA6Sp7Ruo2Io8eLKzWm0=
+github.com/google/uuid v1.1.4/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/middleware/auth/cognitoJwtAuth.go
+++ b/middleware/auth/cognitoJwtAuth.go
@@ -10,7 +10,6 @@ import (
 	"github.com/TheYeung1/yata-server/config"
 	"github.com/TheYeung1/yata-server/server/request"
 	"github.com/dgrijalva/jwt-go"
-	log "github.com/sirupsen/logrus"
 )
 
 type CognitoJwtAuthMiddleware struct {
@@ -19,6 +18,7 @@ type CognitoJwtAuthMiddleware struct {
 
 func (middleware CognitoJwtAuthMiddleware) Execute(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log := request.Logger(r.Context())
 		tokenString := r.Header.Get("Authorization")
 		if len(tokenString) == 0 {
 			log.Error("request does not contain an Auth token")

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/TheYeung1/yata-server/server/request"
+	"github.com/sirupsen/logrus"
+)
+
+func RequestLogger(newID func() string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// TODO: We share part of this next line with request/context.go; consider refactor so we eliminate the risk of de-sync.
+			next.ServeHTTP(w, r.WithContext(request.WithLogger(r.Context(), logrus.WithField("requestID", newID()))))
+		})
+	}
+}

--- a/server/request/context.go
+++ b/server/request/context.go
@@ -2,7 +2,9 @@ package request
 
 import (
 	"context"
+
 	"github.com/TheYeung1/yata-server/model"
+	"github.com/sirupsen/logrus"
 )
 
 type ctxKey string
@@ -20,4 +22,24 @@ func UserID(ctx context.Context) (model.UserID, bool) {
 	val := ctx.Value(userIDContextKey)
 	str, ok := val.(string)
 	return model.UserID(str), ok
+}
+
+const loggerCtxKey ctxKey = "logger"
+
+// Logger returns the logger stored on the context.
+// If a logger was not found a new one will be created with an unknown request ID.
+func Logger(ctx context.Context) *logrus.Entry {
+	e, ok := ctx.Value(loggerCtxKey).(*logrus.Entry)
+	if !ok {
+		// TODO: We share this next line with middleware/logger.go; consider refactor so we eliminate the risk of de-sync.
+		e = logrus.WithField("requestID", "UNKNOWN")
+		e.Warn("failed to find logger on the context")
+	}
+	return e
+}
+
+// WithLogger stores the logger on the returned context.
+// Should only be used by the RequestLogger middleware and tests.
+func WithLogger(ctx context.Context, logger *logrus.Entry) context.Context {
+	return context.WithValue(ctx, loggerCtxKey, logger)
 }

--- a/server/request/context_test.go
+++ b/server/request/context_test.go
@@ -1,0 +1,18 @@
+package request
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogger(t *testing.T) {
+	// Test the logger returned when no logger is set on the context.
+	assert.Equal(t, logrus.Fields{"requestID": "UNKNOWN"}, Logger(context.Background()).Data)
+
+	// Test when a logger is set on the context.
+	lggr := logrus.WithField("foo", "bar")
+	assert.Equal(t, lggr, Logger(WithLogger(context.Background(), lggr)))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/TheYeung1/yata-server/config"
 	"github.com/TheYeung1/yata-server/database"
+	"github.com/TheYeung1/yata-server/middleware"
 	"github.com/TheYeung1/yata-server/middleware/auth"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 )
@@ -19,6 +21,13 @@ func (s *Server) Start() {
 	addr := ":8888"
 	log.WithField("address", addr).Info("starting server")
 	r := mux.NewRouter()
+	r.Use(middleware.RequestLogger(func() string {
+		u, err := uuid.NewRandom()
+		if err != nil {
+			log.Fatalf("failed to generate a uuid: %v", err) // If we get here bad things have happened (ie, we cannot read from crypto/rand's random reader).
+		}
+		return u.String()
+	}))
 	r.Use(auth.CognitoJwtAuthMiddleware{Cfg: s.CognitoCfg}.Execute)
 	r.HandleFunc("/items", s.GetAllItems).Methods(http.MethodGet)
 	r.HandleFunc("/lists", s.GetLists).Methods(http.MethodGet)

--- a/server/util.go
+++ b/server/util.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/TheYeung1/yata-server/model"
 	"github.com/TheYeung1/yata-server/server/request"
-	log "github.com/sirupsen/logrus"
 )
 
 // getUserIDFromContext returns the userID stored on the request context.
@@ -40,20 +39,20 @@ type responseError struct {
 
 // renderJSON writes the response code, sets the content type for JSON, and encodes v as JSON to w.
 // In an ideal world we might want to look at the incoming request's "Accept" header.
-func renderJSON(w http.ResponseWriter, code int, v interface{}) {
+func renderJSON(w http.ResponseWriter, r *http.Request, code int, v interface{}) {
 	w.WriteHeader(code)
 	w.Header().Set("Content-Type", "application/json") // FYI: https://stackoverflow.com/questions/477816/what-is-the-correct-json-content-type
 	if err := json.NewEncoder(w).Encode(v); err != nil {
-		log.WithError(err).Warn("failed to render json")
+		request.Logger(r.Context()).WithError(err).Warn("failed to render json")
 	}
 }
 
-func renderInternalServerError(w http.ResponseWriter) {
-	renderJSON(w, http.StatusInternalServerError, responseError{Code: "InternalServerError"})
+func renderInternalServerError(w http.ResponseWriter, r *http.Request) {
+	renderJSON(w, r, http.StatusInternalServerError, responseError{Code: "InternalServerError"})
 }
 
-func renderBadRequest(w http.ResponseWriter, msg string) {
-	renderJSON(w, http.StatusBadRequest, responseError{Code: "BadRequest", Message: msg})
+func renderBadRequest(w http.ResponseWriter, r *http.Request, msg string) {
+	renderJSON(w, r, http.StatusBadRequest, responseError{Code: "BadRequest", Message: msg})
 }
 
 func validateListID(id model.ListID) error {


### PR DESCRIPTION
# Overview

This code change updates how we handle logging to use a different logger per request. It also removes all logging from non-handlers and decorates returned errors to ensure we keep the context that was in the removed log statements.

# Testing

1. ran the server
2. hit all the endpoints described in the README. Observed the log statements all had different `requestID`s.

## Example Log Entries

```
DEBU[0299]/mnt/c/Users/hhjones/Synced/Personal/yata-server/middleware/auth/cognitoJwtAuth.go:56 github.com/TheYeung1/yata-server/middleware/auth.CognitoJwtAuthMiddleware.Execute.func1() claims validated                              claims="&{true id 1609950478 harrison  harrisonhjones@gmail.com {6s1uu5tpmohl4j39h7tq1h3vfi 1609954078  1609950478 https://cognito-idp.us-east-1.amazonaws.com/us-east-1_cFFhb1izH 0 de6aaeb8-6afa-4641-a5a2-3e1c1ebd521c}}" requestID=4a52e457-8962-4c99-ae99-df4238cef3e5
DEBU[0299]/mnt/c/Users/hhjones/Synced/Personal/yata-server/server/getlists.go:24 github.com/TheYeung1/yata-server/server.(*Server).GetList() get list called                               requestID=4a52e457-8962-4c99-ae99-df4238cef3e5 userID=de6aaeb8-6afa-4641-a5a2-3e1c1ebd521c
INFO[0299]/mnt/c/Users/hhjones/Synced/Personal/yata-server/server/getlists.go:37 github.com/TheYeung1/yata-server/server.(*Server).GetList() list not found                                error="list not found. UserID: \"de6aaeb8-6afa-4641-a5a2-3e1c1ebd521c\", ListID: \"ID3\"" requestID=4a52e457-8962-4c99-ae99-df4238cef3e5
```