### PR TITLE
Add support for CORS

### DIFF
--- a/middleware/CORSMiddleware.go
+++ b/middleware/CORSMiddleware.go
@@ -1,0 +1,18 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+func CORSAccessControlHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization")
+		if r.Method == http.MethodOptions {
+			// According to the mux documentation, if a request is terminated then ResponseWriter should be written to
+			w.Write([]byte{})
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -28,12 +28,14 @@ func (s *Server) Start() {
 		}
 		return u.String()
 	}))
-	r.Use(auth.CognitoJwtAuthMiddleware{Cfg: s.CognitoCfg}.Execute)
-	r.HandleFunc("/items", s.GetAllItems).Methods(http.MethodGet)
-	r.HandleFunc("/lists", s.GetLists).Methods(http.MethodGet)
-	r.HandleFunc("/lists", s.InsertList).Methods(http.MethodPut)
-	r.HandleFunc("/lists/{listID}/", s.GetList).Methods(http.MethodGet)
-	r.HandleFunc("/lists/{listID}/items", s.GetListItems).Methods(http.MethodGet)
-	r.HandleFunc("/lists/{listID}/items", s.InsertListItem).Methods(http.MethodPut)
+	r.Use(mux.CORSMethodMiddleware(r),
+		middleware.CORSAccessControlHeadersMiddleware,
+		auth.CognitoJwtAuthMiddleware{Cfg: s.CognitoCfg}.Execute)
+	r.HandleFunc("/items", s.GetAllItems).Methods(http.MethodGet, http.MethodOptions)
+	r.HandleFunc("/lists", s.GetLists).Methods(http.MethodGet, http.MethodOptions)
+	r.HandleFunc("/lists", s.InsertList).Methods(http.MethodPut, http.MethodOptions)
+	r.HandleFunc("/lists/{listID}/", s.GetList).Methods(http.MethodGet, http.MethodOptions)
+	r.HandleFunc("/lists/{listID}/items", s.GetListItems).Methods(http.MethodGet, http.MethodOptions)
+	r.HandleFunc("/lists/{listID}/items", s.InsertListItem).Methods(http.MethodPut, http.MethodOptions)
 	log.Fatal(http.ListenAndServe(addr, r))
 }


### PR DESCRIPTION
This is a draft pull request. It is not ready to be reviewed yet. Putting this out there incase we decide to go with CORS.

This change still needs tests and the code needs to be formatted correctly. Commit message also needs more details.


Essentially this adds middleware to set the correct Allow* headers needed for the CORS prerequest. The custom added CORS middleware will short circuit the request if the method is OPTIONS. Another way to do this is to short circuit the request in each handler for each API instead. This approach is taken in the mux CORS example.